### PR TITLE
Move to python 3.9.5 and upgrade requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.9.5-alpine
+WORKDIR /src
+RUN apk --no-cache add build-base
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+CMD ["python", "app.py"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  app:
+    build: .
+    ports:
+      - "5000:5000"
+    volumes:
+      - .:/src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-eventlet==0.29.1
-faker==4.14.0
-flask==1.1.2
-gunicorn==20.0.4
-markdown==3.3.3
+eventlet==0.31.0
+Faker==8.2.0
+Flask==2.0.0
+gunicorn==20.1.0
+markdown==3.3.4

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.6
+python-3.9.5


### PR DESCRIPTION
# Summary

- move to python 3.9.5
- upgrade all requirements to latest versions
- 