### PR TITLE
Pin eventlet https://github.com/benoitc/gunicorn/pull/2581

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-eventlet==0.31.0
+eventlet==0.30.2
 Faker==8.2.0
 Flask==2.0.0
 gunicorn==20.1.0


### PR DESCRIPTION
# Summary

- pin eventlet version to avoid `ImportError: cannot import name 'ALREADY_HANDLED' from 'eventlet.wsgi'`
